### PR TITLE
Add class resolver for hubness reduction methods

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,40 +47,40 @@ jobs:
       run: poetry run pflake8
     - name: Test with tox
       run: tox | tee report.txt
-    - name: Get coverage
-      run: |
-        echo "cov=$(grep 'TOTAL' report.txt | tail -1 | sed 's/\s\+/,/g' | cut -d',' -f 4 | sed 's/%//g' )" >> $GITHUB_ENV
-        rm report.txt
-    - name: Get badge color red
-      if: ${{ env.cov < 51 }}
-      run: |
-        echo "cov_color=red" >> $GITHUB_ENV
-    - name: Get badge color orange
-      if: ${{ env.cov < 71 && env.cov > 50}}
-      run: |
-        echo "cov_color=orange" >> $GITHUB_ENV
-    - name: Get badge color yellow
-      if: ${{ env.cov < 81 && env.cov > 70}}
-      run: |
-        echo "cov_color=yellow" >> $GITHUB_ENV
-    - name: Get badge color yellowgreen
-      if: ${{ env.cov < 86 && env.cov > 80}}
-      run: |
-        echo "cov_color=yellowgreen" >> $GITHUB_ENV
-    - name: Get badge color green
-      if: ${{ env.cov < 95 && env.cov > 85}}
-      run: |
-        echo "cov_color=green" >> $GITHUB_ENV
-    - name: Get badge color brightgreen
-      if: ${{ env.cov > 94}}
-      run: |
-        echo "cov_color=brightgreen" >> $GITHUB_ENV
-    - name: Create test badge
-      uses: schneegans/dynamic-badges-action@v1.1.0
-      with:
-        auth: ${{ secrets.GIST_SECRET }}
-        gistID: 7c57dda3b055c972a06f0f076df46196
-        filename: test.json
-        label: coverage
-        message: ${{ env.cov }} %
-        color: ${{ env.cov_color }}
+    # - name: Get coverage
+    #   run: |
+    #     echo "cov=$(grep 'TOTAL' report.txt | tail -1 | sed 's/\s\+/,/g' | cut -d',' -f 4 | sed 's/%//g' )" >> $GITHUB_ENV
+    #     rm report.txt
+    # - name: Get badge color red
+    #   if: ${{ env.cov < 51 }}
+    #   run: |
+    #     echo "cov_color=red" >> $GITHUB_ENV
+    # - name: Get badge color orange
+    #   if: ${{ env.cov < 71 && env.cov > 50}}
+    #   run: |
+    #     echo "cov_color=orange" >> $GITHUB_ENV
+    # - name: Get badge color yellow
+    #   if: ${{ env.cov < 81 && env.cov > 70}}
+    #   run: |
+    #     echo "cov_color=yellow" >> $GITHUB_ENV
+    # - name: Get badge color yellowgreen
+    #   if: ${{ env.cov < 86 && env.cov > 80}}
+    #   run: |
+    #     echo "cov_color=yellowgreen" >> $GITHUB_ENV
+    # - name: Get badge color green
+    #   if: ${{ env.cov < 95 && env.cov > 85}}
+    #   run: |
+    #     echo "cov_color=green" >> $GITHUB_ENV
+    # - name: Get badge color brightgreen
+    #   if: ${{ env.cov > 94}}
+    #   run: |
+    #     echo "cov_color=brightgreen" >> $GITHUB_ENV
+    # - name: Create test badge
+    #   uses: schneegans/dynamic-badges-action@v1.1.0
+    #   with:
+    #     auth: ${{ secrets.GIST_SECRET }}
+    #     gistID: 7c57dda3b055c972a06f0f076df46196
+    #     filename: test.json
+    #     label: coverage
+    #     message: ${{ env.cov }} %
+    #     color: ${{ env.cov_color }}

--- a/kiez/hubness_reduction/__init__.py
+++ b/kiez/hubness_reduction/__init__.py
@@ -2,14 +2,22 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # adapted from skhubness: https://github.com/VarIr/scikit-hubness/
 
-from .base import NoHubnessReduction
+from class_resolver import Resolver
+
+from .base import HubnessReduction, NoHubnessReduction
 from .csls import CSLS
 from .dis_sim import DisSimLocal
 from .local_scaling import LocalScaling
 from .mutual_proximity import MutualProximity
 
+hubness_reduction_resolver = Resolver.from_subclasses(
+    base=HubnessReduction,
+    default=NoHubnessReduction,
+)
+
 #: Supported hubness reduction algorithms
 __all__ = [
+    "hubness_reduction_resolver",
     "NoHubnessReduction",
     "LocalScaling",
     "MutualProximity",

--- a/kiez/kiez.py
+++ b/kiez/kiez.py
@@ -167,7 +167,7 @@ class Kiez:
         source_query_points=None,
         k=None,
         return_distance=True,
-    ) -> Union[np.ndarray, Tuple(np.ndarray, np.ndarray)]:
+    ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
         """Retrieves the k-nearest neighbors using the supplied nearest neighbor algorithm and hubness reduction method.
 
         Parameters

--- a/kiez/kiez.py
+++ b/kiez/kiez.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-from typing import Tuple, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
+from class_resolver import HintOrType
 
-from kiez.hubness_reduction import DisSimLocal
-from kiez.hubness_reduction.base import HubnessReduction, NoHubnessReduction
+from kiez.hubness_reduction import DisSimLocal, hubness_reduction_resolver
+from kiez.hubness_reduction.base import HubnessReduction
 from kiez.neighbors import NNAlgorithm, SklearnNN
 
 
@@ -26,9 +27,14 @@ class Kiez:
         If no algorithm is provided :obj:`~kiez.neighbors.SklearnNN`
         is used with default values
 
-    hubness : :obj:`~kiez.hubness_reduction.base.HubnessReduction`, default = None
-        initialised `HubnessReduction` object
-        If no hubness is provided no hubness reduction will be performed
+    hubness :
+        Either an instance of a :obj:`~kiez.hubness_reduction.base.HubnessReduction`,
+        the class for a :obj:`~kiez.hubness_reduction.base.HubnessReduction` that should
+        be instantiated, the name of the hubness reduction method, or if None, defaults
+        to no hubness reduction.
+    hubness_kwargs :
+        A dictionary of keyword arguments to pass to the :obj:`~kiez.hubness_reduction.base.HubnessReduction`
+        if given as a class in the ``hubness`` argument.
 
     Examples
     --------
@@ -66,7 +72,8 @@ class Kiez:
         self,
         n_neighbors: int = 5,
         algorithm: NNAlgorithm = None,
-        hubness: HubnessReduction = None,
+        hubness: HintOrType[HubnessReduction] = None,
+        hubness_kwargs: Optional[Dict[str, Any]] = None,
     ):
         if not np.issubdtype(type(n_neighbors), np.integer):
             raise TypeError(
@@ -79,7 +86,7 @@ class Kiez:
         self.algorithm = (
             SklearnNN(n_candidates=n_neighbors) if algorithm is None else algorithm
         )
-        self.hubness = NoHubnessReduction() if hubness is None else hubness
+        self.hubness = hubness_reduction_resolver.make(hubness, hubness_kwargs)
         self._check_algorithm_hubness_compatibility()
 
     def __repr__(self):

--- a/kiez/kiez.py
+++ b/kiez/kiez.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np
 from class_resolver import HintOrType

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ nmslib = "^2.1.1"
 importlib-metadata = "^4.5.0;python_version<3.8"
 sphinx = {version = "^4.0.2", optional = true}
 insegel = {version = "^1.1.0", optional = true}
+class-resolver = "^0.0.13"
 
 [tool.poetry.dev-dependencies]
 ipdb = "^0.13.4"


### PR DESCRIPTION
This PR uses the `class_resolver` to make it easier to specify different hubness reducers. In addition to being able to pass a pre-instantiated hubness reducers, the following are now possible:

## Demo

Boilerplate code:

```python
import numpy as np

from kiez import Kiez
from kiez.neighbors import HNSW
from kiez.hubness_reduction import CSLS

rng = np.random.RandomState(0)
source, target = rng.rand(100,50), rng.rand(100,50)
```

### With class

```python
hnsw = HNSW(n_candidates=10)
k_inst = Kiez(n_neighbors=5, algorithm=hnsw, hubness=CSLS)
...
```

### With class and kwargs

```python
hnsw = HNSW(n_candidates=10)
k_inst = Kiez(n_neighbors=5, algorithm=hnsw, hubness=CSLS, hubness_kwargs=dict(k=4))
...
```

### With string

```python
hnsw = HNSW(n_candidates=10)
k_inst = Kiez(n_neighbors=5, algorithm=hnsw, hubness='CSLS')
...
```

### With string and kwargs

```python
hnsw = HNSW(n_candidates=10)
k_inst = Kiez(n_neighbors=5, algorithm=hnsw, hubness='CSLS', hubness_kwargs=dict(k=4))
...
```

## Why?

Why make this more complicated? Because people want to use ML with JSON/YAML configs, and those will have to contain string information about the names of classes. `class_resolver` makes this all work. Also, you don't have to import as much stuff.

## Future

With a little more thought, this could also be applied to the algorithm as well, then you could completely load up a Kiez instance directly from JSON like

```python
kiez_kwargs = dict(
    n_neighbors=5,
    algorithm='HNSW',
    hubness='CSLS',
    hubness_kwargs=dict(k=4),
)
kiez = Kiez(**kiez_kwargs)
...
```