### PR TITLE
Add ability to specify algorithm via class-resolver

### DIFF
--- a/kiez/kiez.py
+++ b/kiez/kiez.py
@@ -9,7 +9,7 @@ from class_resolver import HintOrType
 
 from kiez.hubness_reduction import DisSimLocal, hubness_reduction_resolver
 from kiez.hubness_reduction.base import HubnessReduction
-from kiez.neighbors import NNAlgorithm, SklearnNN
+from kiez.neighbors import NNAlgorithm, SklearnNN, nn_algorithm_resolver
 
 
 class Kiez:
@@ -26,6 +26,9 @@ class Kiez:
         initialised `NNAlgorithm` object that will be used for neighbor search
         If no algorithm is provided :obj:`~kiez.neighbors.SklearnNN`
         is used with default values
+    algorithm_kwargs :
+        A dictionary of keyword arguments to pass to the :obj:`~kiez.neighbors.NNAlgorithm`
+        if given as a class in the ``algorithm`` argument.
 
     hubness :
         Either an instance of a :obj:`~kiez.hubness_reduction.base.HubnessReduction`,
@@ -71,7 +74,8 @@ class Kiez:
     def __init__(
         self,
         n_neighbors: int = 5,
-        algorithm: NNAlgorithm = None,
+        algorithm: HintOrType[NNAlgorithm] = None,
+        algorithm_kwargs: Optional[Dict[str, Any]] = None,
         hubness: HintOrType[HubnessReduction] = None,
         hubness_kwargs: Optional[Dict[str, Any]] = None,
     ):
@@ -83,9 +87,7 @@ class Kiez:
         elif n_neighbors <= 0:
             raise ValueError(f"Expected n_neighbors > 0. Got {n_neighbors}")
         self.n_neighbors = n_neighbors
-        self.algorithm = (
-            SklearnNN(n_candidates=n_neighbors) if algorithm is None else algorithm
-        )
+        self.algorithm = nn_algorithm_resolver.make(algorithm, algorithm_kwargs)
         self.hubness = hubness_reduction_resolver.make(hubness, hubness_kwargs)
         self._check_algorithm_hubness_compatibility()
 

--- a/kiez/kiez.py
+++ b/kiez/kiez.py
@@ -87,6 +87,8 @@ class Kiez:
         elif n_neighbors <= 0:
             raise ValueError(f"Expected n_neighbors > 0. Got {n_neighbors}")
         self.n_neighbors = n_neighbors
+        if algorithm is None and algorithm_kwargs is None:
+            algorithm_kwargs = dict(n_candidates=n_neighbors)
         self.algorithm = nn_algorithm_resolver.make(algorithm, algorithm_kwargs)
         self.hubness = hubness_reduction_resolver.make(hubness, hubness_kwargs)
         self._check_algorithm_hubness_compatibility()

--- a/kiez/neighbors/__init__.py
+++ b/kiez/neighbors/__init__.py
@@ -1,7 +1,17 @@
+from class_resolver import Resolver
+
 from kiez.neighbors.approximate.hnsw import HNSW
 from kiez.neighbors.approximate.nng import NNG
 from kiez.neighbors.approximate.random_projection_trees import Annoy
 from kiez.neighbors.exact.sklearn_nearest_neighbors import SklearnNN
-from kiez.neighbors.neighbor_algorithm_base import NNAlgorithm
+from kiez.neighbors.neighbor_algorithm_base import NNAlgorithm, NNAlgorithmWithJoblib
 
-__all__ = ["HNSW", "NNG", "Annoy", "SklearnNN", "NNAlgorithm"]
+__all__ = ["nn_algorithm_resolver", "HNSW", "NNG", "Annoy", "SklearnNN", "NNAlgorithm"]
+
+nn_algorithm_resolver = Resolver.from_subclasses(
+    base=NNAlgorithm,
+    skip={  # Skip being able to resolve intermediate base classes
+        NNAlgorithmWithJoblib,
+    },
+    default=SklearnNN,
+)

--- a/tests/test_kiez.py
+++ b/tests/test_kiez.py
@@ -81,8 +81,8 @@ def test_hubness_resolver(n_samples=20, n_features=5):
     source = rng.rand(n_samples, n_features)
     target = rng.rand(n_samples, n_features)
     res = []
-    for algo in [SklearnNN(), None, "SklearnNN", CustomAlgorithm()]:
-        for hub in [NoHubnessReduction(), None, "NoHubnessReduction", CustomHubness()]:
+    for algo in [SklearnNN(), SklearnNN, None, "SklearnNN", CustomAlgorithm, CustomAlgorithm()]:
+        for hub in [NoHubnessReduction(), NoHubnessReduction, None, "NoHubnessReduction", CustomHubness, CustomHubness()]:
             k_inst = Kiez(algorithm=algo, hubness=hub)
             k_inst.fit(source, target)
             res.append(k_inst.kneighbors(source, k=1))

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ skip_missing_interpreters = true
 
 [testenv]
 whitelist_externals = poetry
+deps =
+  poetry
 commands =
   poetry install -v
   poetry run pytest --cov=kiez tests/


### PR DESCRIPTION
This PR does the same thing as #5 but for the algorithm instead of hubness argument to `Kiev.__init__`.

It still maintains the SklearnNN as the default, and will automatically add the n_candidates in.