### PR TITLE
Add function for loading Kiez object from JSON configuration

### DIFF
--- a/kiez/kiez.py
+++ b/kiez/kiez.py
@@ -99,6 +99,12 @@ class Kiez:
             f" hubness: {self.hubness})"
             f" {self.algorithm._describe_source_target_fitted()}"
         )
+    
+    @classmethod
+    def from_path(cls, path: Union[str, Path]) -> Kiez:
+        """Load a Kiez instance from configuration in a JSON file, based on its path."""
+        with open(path) as file:
+            return cls(**json.load(file))
 
     def _kcandidates(
         self, query_points, *, s_to_t=True, k=None, return_distance=True

--- a/kiez/kiez.py
+++ b/kiez/kiez.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np

--- a/kiez/kiez.py
+++ b/kiez/kiez.py
@@ -101,7 +101,7 @@ class Kiez:
             f" hubness: {self.hubness})"
             f" {self.algorithm._describe_source_target_fitted()}"
         )
-    
+
     @classmethod
     def from_path(cls, path: Union[str, Path]) -> Kiez:
         """Load a Kiez instance from configuration in a JSON file, based on its path."""

--- a/tests/example_conf.json
+++ b/tests/example_conf.json
@@ -1,0 +1,10 @@
+{
+  "algorithm": "HNSW",
+  "algorithm_kwargs": {
+    "n_candidates": 10
+  },
+  "hubness": "LocalScaling",
+  "hubness_kwargs": {
+    "method": "NICDM"
+  }
+}

--- a/tests/test_kiez.py
+++ b/tests/test_kiez.py
@@ -166,9 +166,7 @@ def test_from_config():
     kiez = Kiez.from_path(path)
     assert kiez.hubness is not None
     assert isinstance(kiez.hubness, HubnessReduction)
-    assert isinstance(
-        kiez.hubness, LocalScaling
-    ), f"wrong hubness: {kiez.hubness.__class__.__name__}"
+    assert isinstance(kiez.hubness, LocalScaling), f"wrong hubness: {kiez.hubness}"
     assert kiez.algorithm is not None
-    assert isinstance(kiez.algorithm, NNAlgorithm), f"wrong algorithm: {kiez.algorithm}"
+    assert isinstance(kiez.algorithm, NNAlgorithm)
     assert isinstance(kiez.algorithm, HNSW), f"wrong algorithm: {kiez.algorithm}"

--- a/tests/test_kiez.py
+++ b/tests/test_kiez.py
@@ -2,13 +2,17 @@ import pathlib
 
 import numpy as np
 import pytest
-
-from hubness_reduction import LocalScaling
-from kiez import Kiez
-from kiez.hubness_reduction import DisSimLocal, HubnessReduction, NoHubnessReduction
-from kiez.neighbors import HNSW, NNAlgorithm, SklearnNN
 from numpy.testing import assert_array_equal
 from sklearn.neighbors import NearestNeighbors
+
+from kiez import Kiez
+from kiez.hubness_reduction import (
+    DisSimLocal,
+    HubnessReduction,
+    LocalScaling,
+    NoHubnessReduction,
+)
+from kiez.neighbors import HNSW, NNAlgorithm, SklearnNN
 
 HERE = pathlib.Path(__file__).parent.resolve()
 rng = np.random.RandomState(2)
@@ -34,7 +38,7 @@ class CustomHubness(HubnessReduction):
         assume_sorted=True,
         return_distance=True,
         *args,
-        **kwargs
+        **kwargs,
     ):
         if return_distance:
             return neigh_dist, neigh_ind
@@ -162,7 +166,9 @@ def test_from_config():
     kiez = Kiez.from_path(path)
     assert kiez.hubness is not None
     assert isinstance(kiez.hubness, HubnessReduction)
-    assert isinstance(kiez.hubness, LocalScaling), f'wrong hubness: {kiez.hubness.__class__.__name__}'
+    assert isinstance(
+        kiez.hubness, LocalScaling
+    ), f"wrong hubness: {kiez.hubness.__class__.__name__}"
     assert kiez.algorithm is not None
-    assert isinstance(kiez.algorithm, NNAlgorithm), f'wrong algorithm: {kiez.algorithm}'
-    assert isinstance(kiez.algorithm, HNSW), f'wrong algorithm: {kiez.algorithm}'
+    assert isinstance(kiez.algorithm, NNAlgorithm), f"wrong algorithm: {kiez.algorithm}"
+    assert isinstance(kiez.algorithm, HNSW), f"wrong algorithm: {kiez.algorithm}"

--- a/tests/test_kiez.py
+++ b/tests/test_kiez.py
@@ -1,11 +1,16 @@
+import pathlib
+
 import numpy as np
 import pytest
+
+from hubness_reduction import LocalScaling
 from kiez import Kiez
 from kiez.hubness_reduction import DisSimLocal, HubnessReduction, NoHubnessReduction
 from kiez.neighbors import HNSW, NNAlgorithm, SklearnNN
 from numpy.testing import assert_array_equal
 from sklearn.neighbors import NearestNeighbors
 
+HERE = pathlib.Path(__file__).parent.resolve()
 rng = np.random.RandomState(2)
 
 
@@ -150,3 +155,14 @@ def test_dis_sim_local_wrong_metric():
 def test_dis_sim_local_squaring():
     k_inst = Kiez(algorithm=HNSW(metric="sqeuclidean"), hubness=DisSimLocal())
     assert k_inst.hubness.squared
+
+
+def test_from_config():
+    path = HERE.joinpath("example_conf.json")
+    kiez = Kiez.from_path(path)
+    assert kiez.hubness is not None
+    assert isinstance(kiez.hubness, HubnessReduction)
+    assert isinstance(kiez.hubness, LocalScaling), f'wrong hubness: {kiez.hubness.__class__.__name__}'
+    assert kiez.algorithm is not None
+    assert isinstance(kiez.algorithm, NNAlgorithm), f'wrong algorithm: {kiez.algorithm}'
+    assert isinstance(kiez.algorithm, HNSW), f'wrong algorithm: {kiez.algorithm}'


### PR DESCRIPTION
Since #5 and #6 enable string-based instantiation of a Kiez object, it makes sense to be able to completely store a Kiez configuration in a JSON object and load from there. This PR implements loading based on a file path that simply opens the file, parses JSON, then splats the arguments into the Kiez constructor. It also adds a corresponding unit test (which weirdly is acting funny on my computer, but is pretty obvious what it does)