### PR TITLE
Enable torch

### DIFF
--- a/kiez/hubness_reduction/csls.py
+++ b/kiez/hubness_reduction/csls.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 from sklearn.utils.validation import check_is_fitted
-from tqdm.auto import tqdm
 
 from .base import HubnessReduction
 
@@ -84,27 +83,13 @@ class CSLS(HubnessReduction):
         """
         check_is_fitted(self, "r_dist_train_")
 
-        n_test, n_indexed = neigh_dist.shape
-
         # Find average distances to the k nearest neighbors
         r_dist_test = neigh_dist
 
-        hub_reduced_dist = np.empty_like(neigh_dist)
-
-        # Optionally show progress of local scaling loop
-        disable_tqdm = not self.verbose
-        range_n_test = tqdm(
-            range(n_test),
-            desc="CSLS",
-            disable=disable_tqdm,
-        )
-
         r_train = self.r_dist_train_.mean(axis=1)
-        r_test = r_dist_test.mean(axis=1)
-        for i in range_n_test:
-            hub_reduced_dist[i, :] = (
-                2 * neigh_dist[i] - r_test[i] - r_train[neigh_ind[i]]
-            )
+        r_test = r_dist_test.mean(axis=1).reshape(-1, 1)
+
+        hub_reduced_dist = 2 * neigh_dist - r_test - r_train[neigh_ind]
         # Return the hubness reduced distances
         # These must be sorted downstream
         return hub_reduced_dist, neigh_ind

--- a/kiez/hubness_reduction/csls.py
+++ b/kiez/hubness_reduction/csls.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import numpy as np
 from sklearn.utils.validation import check_is_fitted
 
@@ -29,7 +27,7 @@ class CSLS(HubnessReduction):
         neigh_ind,
         source=None,
         target=None,
-    ) -> CSLS:
+    ) -> "CSLS":
         """Fit the model using target, neigh_dist, and neigh_ind as training data.
 
         Parameters

--- a/kiez/hubness_reduction/dis_sim.py
+++ b/kiez/hubness_reduction/dis_sim.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # adapted from skhubness: https://github.com/VarIr/scikit-hubness/
 
-from __future__ import annotations
-
 import numpy as np
 from sklearn.metrics import euclidean_distances
 from sklearn.utils.extmath import row_norms
@@ -12,6 +10,11 @@ from .base import HubnessReduction
 
 _DESIRED_P_VALUE = 2
 _MINIMUM_DIST = 0.0
+
+try:
+    import torch
+except ImportError:
+    torch = None
 
 
 class DisSimLocal(HubnessReduction):
@@ -58,24 +61,24 @@ class DisSimLocal(HubnessReduction):
 
     def _fit(
         self,
-        neigh_dist: np.ndarray,
-        neigh_ind: np.ndarray,
-        source: np.ndarray,
-        target: np.ndarray,
-    ) -> DisSimLocal:
+        neigh_dist,
+        neigh_ind,
+        source,
+        target,
+    ) -> "DisSimLocal":
         """Fit the model using target, neigh_dist, and neigh_ind as training data.
 
         Parameters
         ----------
-        neigh_dist: np.ndarray, shape (n_samples, n_neighbors)
+        neigh_dist: shape (n_samples, n_neighbors)
             Distance matrix of training objects (rows) against their
             individual k nearest neighbors (colums).
-        neigh_ind: np.ndarray, shape (n_samples, n_neighbors)
+        neigh_ind: shape (n_samples, n_neighbors)
             Neighbor indices corresponding to the values in neigh_dist.
-        source: np.ndarray, shape (n_samples, n_features)
+        source: shape (n_samples, n_features)
             source embedding, where n_samples is the number of vectors,
             and n_features their dimensionality (number of features).
-        target: np.ndarray, shape (n_samples, n_features)
+        target: shape (n_samples, n_features)
             Target embedding, where n_samples is the number of vectors,
             and n_features their dimensionality (number of features).
 
@@ -97,20 +100,20 @@ class DisSimLocal(HubnessReduction):
 
     def transform(
         self,
-        neigh_dist: np.ndarray,
-        neigh_ind: np.ndarray,
-        query: np.ndarray,
+        neigh_dist,
+        neigh_ind,
+        query,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Transform distance between test and training data with DisSimLocal.
 
         Parameters
         ----------
-        neigh_dist: np.ndarray, shape (n_query, n_neighbors)
+        neigh_dist: shape (n_query, n_neighbors)
             Distance matrix of test objects (rows) against their individual
             k nearest neighbors among the training data (columns).
-        neigh_ind: np.ndarray, shape (n_query, n_neighbors)
+        neigh_ind: shape (n_query, n_neighbors)
             Neighbor indices corresponding to the values in neigh_dist
-        query: np.ndarray, shape (n_query, n_features)
+        query: shape (n_query, n_features)
             Query entities that were used to obtain neighbors
             If none is provided use source that was provided in fit step
 
@@ -128,26 +131,47 @@ class DisSimLocal(HubnessReduction):
             self,
             ["target_", "target_centroids_", "target_dist_to_centroids_"],
         )
-        # Calculate local neighborhood centroids for source objects among target objects
-        k = neigh_ind.shape[1]
-        mask = np.argpartition(neigh_dist, kth=k - 1)
-        for i, ind in enumerate(neigh_ind):
-            neigh_dist[i, :] = euclidean_distances(
-                query[i].reshape(1, -1), self.target_[ind], squared=True
-            )
+        if torch and isinstance(neigh_ind, torch.Tensor):
+            # Calculate local neighborhood centroids for source objects among target objects
+            knn = neigh_ind
 
-        neigh_ind = np.take_along_axis(neigh_ind, mask, axis=1)
-        knn = neigh_ind[:, :k]
-        centroids = self.target_[knn].mean(axis=1)
+            # pairwise squared euclidean distance between each query vector and knn
+            # unsqueeze to enable batching
+            neigh_dist = torch.cdist(
+                torch.unsqueeze(query, 0), self.target_[neigh_ind]
+            ).pow(2)
 
-        source_minus_centroids = query - centroids
-        source_minus_centroids **= 2
-        source_dist_to_centroids = source_minus_centroids.sum(axis=1)
-        target_dist_to_centroids = self.target_dist_to_centroids_[neigh_ind]
+            centroids = self.target_[knn].mean(axis=1)
 
-        hub_reduced_dist = neigh_dist.copy()
-        hub_reduced_dist -= source_dist_to_centroids[:, np.newaxis]
-        hub_reduced_dist -= target_dist_to_centroids
+            source_minus_centroids = query - centroids
+            source_minus_centroids **= 2
+            source_dist_to_centroids = source_minus_centroids.sum(axis=1)
+            target_dist_to_centroids = self.target_dist_to_centroids_[neigh_ind]
+
+            hub_reduced_dist = neigh_dist.copy()
+            hub_reduced_dist -= source_dist_to_centroids.reshape(-1, 1)
+            hub_reduced_dist -= target_dist_to_centroids
+        else:
+            # Calculate local neighborhood centroids for source objects among target objects
+            k = neigh_ind.shape[1]
+            mask = np.argpartition(neigh_dist, kth=k - 1)
+            neigh_ind = np.take_along_axis(neigh_ind, mask, axis=1)
+            knn = neigh_ind[:, :k]
+
+            for i, ind in enumerate(neigh_ind):
+                neigh_dist[i, :] = euclidean_distances(
+                    query[i].reshape(1, -1), self.target_[ind], squared=True
+                )
+            centroids = self.target_[knn].mean(axis=1)
+
+            source_minus_centroids = query - centroids
+            source_minus_centroids **= 2
+            source_dist_to_centroids = source_minus_centroids.sum(axis=1)
+            target_dist_to_centroids = self.target_dist_to_centroids_[neigh_ind]
+
+            hub_reduced_dist = neigh_dist.copy()
+            hub_reduced_dist -= source_dist_to_centroids[:, np.newaxis]
+            hub_reduced_dist -= target_dist_to_centroids
 
         # DisSimLocal can yield negative dissimilarities, which can cause problems with
         # certain scikit-learn routines (e.g. in metric='precomputed' usages).

--- a/kiez/hubness_reduction/dis_sim.py
+++ b/kiez/hubness_reduction/dis_sim.py
@@ -138,7 +138,7 @@ class DisSimLocal(HubnessReduction):
         )
         if torch and isinstance(neigh_ind, torch.Tensor):
             # Calculate local neighborhood centroids for source objects among target objects
-            knn = neigh_ind
+            knn = neigh_ind[:, : neigh_ind.shape[1]]
 
             # pairwise squared euclidean distance between each query vector and knn
             # unsqueeze to enable batching

--- a/kiez/hubness_reduction/dis_sim.py
+++ b/kiez/hubness_reduction/dis_sim.py
@@ -142,7 +142,7 @@ class DisSimLocal(HubnessReduction):
 
             # pairwise squared euclidean distance between each query vector and knn
             # unsqueeze to enable batching
-            neigh_dist = torch.cdist(
+            hub_reduced_dist = torch.cdist(
                 torch.unsqueeze(query, 0), self.target_[neigh_ind]
             ).pow(2)
 
@@ -153,7 +153,6 @@ class DisSimLocal(HubnessReduction):
             source_dist_to_centroids = source_minus_centroids.sum(axis=1)
             target_dist_to_centroids = self.target_dist_to_centroids_[neigh_ind]
 
-            hub_reduced_dist = neigh_dist.copy()
             hub_reduced_dist -= source_dist_to_centroids.reshape(-1, 1)
             hub_reduced_dist -= target_dist_to_centroids
         else:

--- a/kiez/hubness_reduction/dis_sim.py
+++ b/kiez/hubness_reduction/dis_sim.py
@@ -138,13 +138,16 @@ class DisSimLocal(HubnessReduction):
         )
         if torch and isinstance(neigh_ind, torch.Tensor):
             # Calculate local neighborhood centroids for source objects among target objects
-            knn = neigh_ind[:, : neigh_ind.shape[1]]
+            knn = neigh_ind
 
             # pairwise squared euclidean distance between each query vector and knn
             # unsqueeze to enable batching
             hub_reduced_dist = torch.cdist(
                 torch.unsqueeze(query, 0), self.target_[neigh_ind]
             ).pow(2)
+
+            print("torch")
+            print(hub_reduced_dist.shape)
 
             centroids = self.target_[knn].mean(axis=1)
 
@@ -166,6 +169,8 @@ class DisSimLocal(HubnessReduction):
                 neigh_dist[i, :] = euclidean_distances(
                     query[i].reshape(1, -1), self.target_[ind], squared=True
                 )
+            print("np")
+            print(neigh_dist.shape)
             centroids = self.target_[knn].mean(axis=1)
 
             source_minus_centroids = query - centroids

--- a/kiez/hubness_reduction/dis_sim.py
+++ b/kiez/hubness_reduction/dis_sim.py
@@ -90,7 +90,12 @@ class DisSimLocal(HubnessReduction):
         # Calculate local neighborhood centroids among the training points
         knn = neigh_ind
         centroids = source[knn].mean(axis=1)
-        dist_to_cent = row_norms(target - centroids, squared=True)
+        if torch and isinstance(centroids, torch.Tensor):
+            # see https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/utils/extmath.py#L87C21-L87C48
+            X = target - centroids
+            dist_to_cent = torch.einsum("ij,ij->i", X, X)
+        else:
+            dist_to_cent = row_norms(target - centroids, squared=True)
 
         self.source_ = source
         self.target_ = target

--- a/kiez/hubness_reduction/dis_sim.py
+++ b/kiez/hubness_reduction/dis_sim.py
@@ -128,8 +128,6 @@ class DisSimLocal(HubnessReduction):
             self,
             ["target_", "target_centroids_", "target_dist_to_centroids_"],
         )
-        n_test, n_indexed = neigh_dist.shape
-
         # Calculate local neighborhood centroids for source objects among target objects
         k = neigh_ind.shape[1]
         mask = np.argpartition(neigh_dist, kth=k - 1)
@@ -137,6 +135,7 @@ class DisSimLocal(HubnessReduction):
             neigh_dist[i, :] = euclidean_distances(
                 query[i].reshape(1, -1), self.target_[ind], squared=True
             )
+
         neigh_ind = np.take_along_axis(neigh_ind, mask, axis=1)
         knn = neigh_ind[:, :k]
         centroids = self.target_[knn].mean(axis=1)

--- a/kiez/hubness_reduction/local_scaling.py
+++ b/kiez/hubness_reduction/local_scaling.py
@@ -135,7 +135,7 @@ class LocalScaling(HubnessReduction):
             if torch and isinstance(inner_sqrt, torch.Tensor):
                 sqrt = torch.sqrt(inner_sqrt)
             else:
-                exp = np.sqrt(inner_sqrt)
+                sqrt = np.sqrt(inner_sqrt)
             hub_reduced_dist = neigh_dist / sqrt
 
         # Return the hubness reduced distances

--- a/kiez/hubness_reduction/local_scaling.py
+++ b/kiez/hubness_reduction/local_scaling.py
@@ -1,11 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # adapted from skhubness: https://github.com/VarIr/scikit-hubness/
 
-from __future__ import annotations
-
 import numpy as np
 from sklearn.utils.validation import check_is_fitted
-from tqdm.auto import tqdm
 
 from .base import HubnessReduction
 
@@ -53,7 +50,7 @@ class LocalScaling(HubnessReduction):
         neigh_ind,
         source,
         target,
-    ) -> LocalScaling:
+    ) -> "LocalScaling":
         """Fit the model using neigh_dist and neigh_ind as training data.
 
         Parameters
@@ -112,38 +109,21 @@ class LocalScaling(HubnessReduction):
         """
         check_is_fitted(self, "r_dist_t_to_s_")
 
-        n_test, n_indexed = neigh_dist.shape
-
         # Find distances to the k-th neighbor (standard LS) or the k neighbors (NICDM)
         r_dist_s_to_t = neigh_dist
-
-        # Calculate LS or NICDM
-        hub_reduced_dist = np.empty_like(neigh_dist)
-
-        # Optionally show progress of local scaling loop
-        disable_tqdm = not self.verbose
-        range_n_test = tqdm(
-            range(n_test),
-            desc=f"LS {self.method}",
-            disable=disable_tqdm,
-        )
 
         # Perform standard local scaling...
         if self.method in ["ls", "standard"]:
             r_t_to_s = self.r_dist_t_to_s_[:, -1]
-            r_s_to_t = r_dist_s_to_t[:, -1]
-            for i in range_n_test:
-                hub_reduced_dist[i, :] = 1.0 - np.exp(
-                    -1 * neigh_dist[i] ** 2 / (r_s_to_t[i] * r_t_to_s[neigh_ind[i]])
-                )
+            r_s_to_t = r_dist_s_to_t[:, -1].reshape(-1, 1)
+            hub_reduced_dist = 1.0 - np.exp(
+                -1 * neigh_dist**2 / (r_s_to_t * r_t_to_s[neigh_ind])
+            )
         # ...or use non-iterative contextual dissimilarity measure
         elif self.method == "nicdm":
             r_t_to_s = self.r_dist_t_to_s_.mean(axis=1)
-            r_s_to_t = r_dist_s_to_t.mean(axis=1)
-            for i in range_n_test:
-                hub_reduced_dist[i, :] = neigh_dist[i] / np.sqrt(
-                    r_s_to_t[i] * r_t_to_s[neigh_ind[i]]
-                )
+            r_s_to_t = r_dist_s_to_t.mean(axis=1).reshape(-1, 1)
+            hub_reduced_dist = neigh_dist / np.sqrt(r_s_to_t * r_t_to_s[neigh_ind])
 
         # Return the hubness reduced distances
         # These must be sorted downstream

--- a/kiez/hubness_reduction/mutual_proximity.py
+++ b/kiez/hubness_reduction/mutual_proximity.py
@@ -142,7 +142,7 @@ class MutualProximity(HubnessReduction):
                 mu = torch.nanmean(neigh_dist, axis=1).reshape(-1, 1)
                 sd = torch.nanstd(neigh_dist, ddof=0, axis=1).reshape(-1, 1)
                 p1 = 1 - Normal(mu, sd).cdf(neigh_dist)
-                p2 = 1 - Normal(mu_t_to_s[neigh_dist], sd_t_to_s_[neigh_dist]).cdf(
+                p2 = 1 - Normal(mu_t_to_s[neigh_ind], sd_t_to_s_[neigh_ind]).cdf(
                     neigh_dist
                 )
             else:
@@ -150,7 +150,7 @@ class MutualProximity(HubnessReduction):
                 sd = np.nanstd(neigh_dist, ddof=0, axis=1).reshape(-1, 1)
                 p1 = stats.norm.sf(neigh_dist, mu, sd)
                 p2 = stats.norm.sf(
-                    neigh_dist, mu_t_to_s[neigh_dist], sd_t_to_s_[neigh_dist]
+                    neigh_dist, mu_t_to_s[neigh_ind], sd_t_to_s_[neigh_ind]
                 )
             hub_reduced_dist = 1 - p1 * p2
         # Calculate MP empiric (slow)

--- a/kiez/hubness_reduction/mutual_proximity.py
+++ b/kiez/hubness_reduction/mutual_proximity.py
@@ -1,16 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # adapted from skhubness: https://github.com/VarIr/scikit-hubness/
 
-from __future__ import annotations
-
 import numpy as np
 from scipy import stats
 from sklearn.utils.validation import check_is_fitted
 from tqdm.auto import tqdm
 
 from .base import HubnessReduction
-
-USE_NEW = True
 
 
 class MutualProximity(HubnessReduction):
@@ -59,7 +55,7 @@ class MutualProximity(HubnessReduction):
         neigh_ind,
         source,
         target,
-    ) -> MutualProximity:
+    ) -> "MutualProximity":
         """Fit the model using neigh_dist and neigh_ind as training data.
 
         Parameters

--- a/kiez/hubness_reduction/mutual_proximity.py
+++ b/kiez/hubness_reduction/mutual_proximity.py
@@ -91,8 +91,12 @@ class MutualProximity(HubnessReduction):
             self.neigh_dist_t_to_s_ = neigh_dist
             self.neigh_ind_t_to_s_ = neigh_ind
         elif self.method == "normal":
-            self.mu_t_to_s_ = np.nanmean(neigh_dist, axis=1)
-            self.sd_t_to_s_ = np.nanstd(neigh_dist, axis=1, ddof=0)
+            if torch and isinstance(neigh_dist, torch.Tensor):
+                self.mu_t_to_s_ = torch.nanmean(neigh_dist, axis=1)
+                self.sd_t_to_s_ = torch.nanstd(neigh_dist, ddof=0, axis=1)
+            else:
+                self.mu_t_to_s_ = np.nanmean(neigh_dist, axis=1)
+                self.sd_t_to_s_ = np.nanstd(neigh_dist, axis=1, ddof=0)
         return self
 
     def transform(self, neigh_dist, neigh_ind, query):

--- a/kiez/hubness_reduction/mutual_proximity.py
+++ b/kiez/hubness_reduction/mutual_proximity.py
@@ -93,10 +93,10 @@ class MutualProximity(HubnessReduction):
         elif self.method == "normal":
             if torch and isinstance(neigh_dist, torch.Tensor):
                 self.mu_t_to_s_ = torch.nanmean(neigh_dist, axis=1)
-                self.sd_t_to_s_ = torch.std(neigh_dist, ddof=0, axis=1)
+                self.sd_t_to_s_ = torch.std(neigh_dist, axis=1)
             else:
                 self.mu_t_to_s_ = np.nanmean(neigh_dist, axis=1)
-                self.sd_t_to_s_ = np.nanstd(neigh_dist, axis=1, ddof=0)
+                self.sd_t_to_s_ = np.nanstd(neigh_dist, axis=1)
         return self
 
     def transform(self, neigh_dist, neigh_ind, query):
@@ -144,14 +144,14 @@ class MutualProximity(HubnessReduction):
             sd_t_to_s_ = self.sd_t_to_s_
             if torch and isinstance(neigh_dist, torch.Tensor):
                 mu = torch.nanmean(neigh_dist, axis=1).reshape(-1, 1)
-                sd = torch.std(neigh_dist, ddof=0, axis=1).reshape(-1, 1)
+                sd = torch.std(neigh_dist, axis=1).reshape(-1, 1)
                 p1 = 1 - Normal(mu, sd).cdf(neigh_dist)
                 p2 = 1 - Normal(mu_t_to_s[neigh_ind], sd_t_to_s_[neigh_ind]).cdf(
                     neigh_dist
                 )
             else:
                 mu = np.nanmean(neigh_dist, axis=1).reshape(-1, 1)
-                sd = np.nanstd(neigh_dist, ddof=0, axis=1).reshape(-1, 1)
+                sd = np.nanstd(neigh_dist, axis=1).reshape(-1, 1)
                 p1 = stats.norm.sf(neigh_dist, mu, sd)
                 p2 = stats.norm.sf(
                     neigh_dist, mu_t_to_s[neigh_ind], sd_t_to_s_[neigh_ind]

--- a/kiez/hubness_reduction/mutual_proximity.py
+++ b/kiez/hubness_reduction/mutual_proximity.py
@@ -93,7 +93,7 @@ class MutualProximity(HubnessReduction):
         elif self.method == "normal":
             if torch and isinstance(neigh_dist, torch.Tensor):
                 self.mu_t_to_s_ = torch.nanmean(neigh_dist, axis=1)
-                self.sd_t_to_s_ = torch.nanstd(neigh_dist, ddof=0, axis=1)
+                self.sd_t_to_s_ = torch.std(neigh_dist, ddof=0, axis=1)
             else:
                 self.mu_t_to_s_ = np.nanmean(neigh_dist, axis=1)
                 self.sd_t_to_s_ = np.nanstd(neigh_dist, axis=1, ddof=0)
@@ -144,7 +144,7 @@ class MutualProximity(HubnessReduction):
             sd_t_to_s_ = self.sd_t_to_s_
             if torch and isinstance(neigh_dist, torch.Tensor):
                 mu = torch.nanmean(neigh_dist, axis=1).reshape(-1, 1)
-                sd = torch.nanstd(neigh_dist, ddof=0, axis=1).reshape(-1, 1)
+                sd = torch.std(neigh_dist, ddof=0, axis=1).reshape(-1, 1)
                 p1 = 1 - Normal(mu, sd).cdf(neigh_dist)
                 p2 = 1 - Normal(mu_t_to_s[neigh_ind], sd_t_to_s_[neigh_ind]).cdf(
                     neigh_dist

--- a/kiez/neighbors/approximate/faiss.py
+++ b/kiez/neighbors/approximate/faiss.py
@@ -7,6 +7,7 @@ from kiez.neighbors.neighbor_algorithm_base import NNAlgorithm
 
 try:
     import faiss
+    import faiss.contrib.torch_utils
 except ImportError:  # pragma: no cover
     faiss = None
 

--- a/kiez/neighbors/approximate/faiss.py
+++ b/kiez/neighbors/approximate/faiss.py
@@ -97,11 +97,6 @@ class Faiss(NNAlgorithm):
             + f"use_gpu={self.use_gpu})"
         )
 
-    def _to_float32(self, data):
-        if data.dtype != "float32":
-            return data.astype("float32")
-        return data
-
     def _fit(self, data, is_source: bool):
         dim = data.shape[1]
         index = faiss.index_factory(dim, self.index_key)
@@ -111,13 +106,12 @@ class Faiss(NNAlgorithm):
             params = faiss.GpuParameterSpace()
         if self.index_param is not None:
             params.set_index_parameters(index, self.index_param)
-        index.add(self._to_float32(data))
+        index.add(data)
         return index
 
     def _kneighbors(self, k, query, index, return_distance, is_self_querying):
         if is_self_querying:
             query = self.source_
-        query = self._to_float32(query)
         dist, ind = index.search(query, k)
         if return_distance:
             if self.metric == "euclidean":

--- a/kiez/neighbors/approximate/faiss.py
+++ b/kiez/neighbors/approximate/faiss.py
@@ -7,9 +7,14 @@ from kiez.neighbors.neighbor_algorithm_base import NNAlgorithm
 
 try:
     import faiss
-    import faiss.contrib.torch_utils
 except ImportError:  # pragma: no cover
     faiss = None
+
+try:
+    import torch  # noqa: I001
+    import faiss.contrib.torch_utils
+except ImportError:  # pragma: no cover
+    torch = None
 
 
 class Faiss(NNAlgorithm):
@@ -115,6 +120,9 @@ class Faiss(NNAlgorithm):
         dist, ind = index.search(query, k)
         if return_distance:
             if self.metric == "euclidean":
-                dist = np.sqrt(dist)
+                if torch and isinstance(dist, torch.Tensor):
+                    dist = torch.sqrt(dist)
+                else:
+                    dist = np.sqrt(dist)
             return dist, ind
         return ind

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,6 +25,7 @@ def test_faiss(session: Session) -> None:
     session.conda_install(
         "-c", "pytorch", "faiss-cpu=1.7.4", "mkl=2021", "blas=1.0=mkl"
     )
+    session.conda_install("-c", "pytorch", "pytorch=2.1.2", "cpuonly")
     session.install(".")
     session.install("autofaiss")
     session.install("pytest")

--- a/tests/hubness_reduction/test_base.py
+++ b/tests/hubness_reduction/test_base.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from kiez.hubness_reduction.base import HubnessReduction
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+skip = not torch
+
+
+@pytest.mark.skipif(skip, reason="PyTorch not installed")
+def test_sorting():
+    rng = np.random.default_rng(seed=42)
+    size = (100, 10)
+    dist = rng.random(size)
+    ind = rng.integers(low=0, high=200, size=size)
+    np_dist, np_ind = HubnessReduction._sort(dist, ind, size[1])
+    assert isinstance(np_dist, np.ndarray)
+    assert isinstance(np_ind, np.ndarray)
+
+    tdist = torch.tensor(dist)
+    tind = torch.tensor(ind)
+    torch_dist, torch_ind = HubnessReduction._sort(tdist, tind, size[1])
+    assert isinstance(torch_dist, torch.Tensor)
+    assert isinstance(torch_ind, torch.Tensor)
+
+    assert_array_equal(torch_dist.numpy(), np_dist)
+    assert_array_equal(torch_ind.numpy(), np_ind)

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -54,7 +54,7 @@ def test_different_instantiations(single_source, source_target):
         ("NoHubnessReduction", {}),
         ("LocalScaling", {"method": "ls"}),
         ("LocalScaling", {"method": "nicdm"}),
-        ("MutualProximity", {"method": "norma"}),
+        ("MutualProximity", {"method": "normal"}),
         ("CSLS", {}),
     ],
 )

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -54,8 +54,8 @@ def test_different_instantiations(single_source, source_target):
 )
 def test_torch_gpu(hubness, source_target):
     k = 3
-    source = torch.tensor(source_target[0]).cuda()
-    target = torch.tensor(source_target[1]).cuda()
+    source = torch.tensor(source_target[0]).to(torch.float32).cuda()
+    target = torch.tensor(source_target[1]).to(torch.float32).cuda()
     device_type = source.device.type
     nn_inst = Faiss(metric="l2", index_key="Flat", use_gpu=True)
     kiez_inst = Kiez(n_candidates=5, algorithm=nn_inst, hubness=hubness)

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -70,6 +70,8 @@ def test_torch_gpu(hubness, hubness_kwargs, source_target):
     )
     kiez_inst.fit(source, target)
     np_dist, np_ind = kiez_inst.kneighbors(k)
+    print(np_dist)
+    print(np_ind)
 
     source = torch.tensor(source).to(torch.float32).cuda()
     target = torch.tensor(target).to(torch.float32).cuda()

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -90,5 +90,5 @@ def test_torch_gpu(hubness, hubness_kwargs, source_target):
     assert dist.shape == (len(source), k)
     assert ind.shape == (len(source), k)
 
-    assert_allclose(np_dist, dist.cpu().numpy())
+    assert_allclose(np_dist, dist.cpu().numpy(), rtol=1.0e-6, atol=1.0e-6)
     assert_array_equal(np_ind, ind.cpu().numpy())

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -62,7 +62,7 @@ def test_different_instantiations(single_source, source_target):
 def test_torch_gpu(hubness, hubness_kwargs, source_target):
     k = 3
     source, target = source_target
-    nn_inst_np = Faiss(metric="l2", index_key="Flat")
+    nn_inst_np = Faiss(metric="euclidean", index_key="Flat")
     kiez_inst = Kiez(
         n_candidates=5,
         algorithm=nn_inst_np,

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -57,7 +57,7 @@ def test_torch_gpu(hubness, source_target):
     source = torch.tensor(source_target[0]).cuda()
     target = torch.tensor(source_target[1]).cuda()
     device_type = source.device.type
-    nn_inst = Faiss(metric="l2", index_key="Flat")
+    nn_inst = Faiss(metric="l2", index_key="Flat", use_gpu=True)
     kiez_inst = Kiez(n_candidates=5, algorithm=nn_inst, hubness=hubness)
     kiez_inst.fit(source, target)
     dist, ind = kiez_inst.kneighbors(k)

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -54,13 +54,16 @@ def test_different_instantiations(single_source, source_target):
 )
 def test_torch_gpu(hubness, source_target):
     k = 3
-    source = torch.tensor(source_target[0])
-    target = torch.tensor(source_target[1])
+    source = torch.tensor(source_target[0]).cuda()
+    target = torch.tensor(source_target[1]).cuda()
+    device_type = source.device.type
     nn_inst = Faiss(metric="l2", index_key="Flat")
     kiez_inst = Kiez(n_candidates=5, algorithm=nn_inst, hubness=hubness)
     kiez_inst.fit(source, target)
     dist, ind = kiez_inst.kneighbors(k)
     assert type(dist) == torch.Tensor
     assert type(ind) == torch.Tensor
+    assert dist.device.type == device_type
+    assert ind.device.type == device_type
     assert dist.shape == (len(source), k)
     assert ind.shape == (len(source), k)

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -1,11 +1,18 @@
 import pytest
 from numpy.testing import assert_array_equal
 
+from kiez import Kiez
 from kiez.neighbors import Faiss
 from kiez.neighbors.util import available_nn_algorithms
 
+try:
+    import torch
+except ImportError:
+    torch = None
+
 NN_ALGORITHMS = available_nn_algorithms()
 skip = Faiss not in NN_ALGORITHMS
+skip2 = not skip and torch and torch.cuda.is_available()
 
 
 @pytest.mark.skipif(skip, reason="Faiss not installed")
@@ -38,3 +45,22 @@ def test_different_instantiations(single_source, source_target):
         # check if repr runs without error
         print(auto.__repr__())
         print(manual.__repr__())
+
+
+@pytest.mark.skipif(skip2, reason="Faiss or PyTorch not installed or no GPU")
+@pytest.mark.parametrize(
+    "hubness",
+    ["NoHubnessReduction", "LocalScaling", "MutualProximity", "CSLS"],
+)
+def test_torch_gpu(hubness, source_target):
+    k = 3
+    source = torch.tensor(source_target[0])
+    target = torch.tensor(source_target[1])
+    nn_inst = Faiss(metric="l2", index_key="Flat")
+    kiez_inst = Kiez(n_candidates=5, algorithm=nn_inst, hubness=hubness)
+    kiez_inst.fit(source, target)
+    dist, ind = kiez_inst.kneighbors(k)
+    assert type(dist) == torch.Tensor
+    assert type(ind) == torch.Tensor
+    assert dist.shape == (len(source), k)
+    assert ind.shape == (len(source), k)

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -62,7 +62,8 @@ def test_different_instantiations(single_source, source_target):
 def test_torch_gpu(hubness, hubness_kwargs, source_target):
     k = 3
     source, target = source_target
-    nn_inst_np = Faiss(metric="euclidean", index_key="Flat")
+    metric = "euclidean"
+    nn_inst_np = Faiss(metric=metric, index_key="Flat")
     kiez_inst = Kiez(
         n_candidates=5,
         algorithm=nn_inst_np,
@@ -75,7 +76,7 @@ def test_torch_gpu(hubness, hubness_kwargs, source_target):
     source = torch.tensor(source).to(torch.float32).cuda()
     target = torch.tensor(target).to(torch.float32).cuda()
     device_type = source.device.type
-    nn_inst = Faiss(metric="l2", index_key="Flat", use_gpu=True)
+    nn_inst = Faiss(metric=metric, index_key="Flat", use_gpu=True)
     kiez_inst = Kiez(
         n_candidates=5,
         algorithm=nn_inst,

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -92,5 +92,6 @@ def test_torch_gpu(hubness, hubness_kwargs, source_target):
     assert dist.shape == (len(source), k)
     assert ind.shape == (len(source), k)
 
-    assert_allclose(np_dist, dist.cpu().numpy(), rtol=1.0e-6, atol=1.0e-6)
+    tolerance = 1.0e-6 if hubness != "MutualProximity" else 1.0e-1
+    assert_allclose(np_dist, dist.cpu().numpy(), rtol=tolerance, atol=tolerance)
     assert_array_equal(np_ind, ind.cpu().numpy())

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -12,7 +12,7 @@ except ImportError:
 
 NN_ALGORITHMS = available_nn_algorithms()
 skip = Faiss not in NN_ALGORITHMS
-skip2 = not skip and torch and torch.cuda.is_available()
+skip2 = skip or not torch or not torch.cuda.is_available()
 
 
 @pytest.mark.skipif(skip, reason="Faiss not installed")

--- a/tests/neighbors/test_faiss.py
+++ b/tests/neighbors/test_faiss.py
@@ -1,5 +1,5 @@
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 
 from kiez import Kiez
 from kiez.neighbors import Faiss
@@ -90,5 +90,5 @@ def test_torch_gpu(hubness, hubness_kwargs, source_target):
     assert dist.shape == (len(source), k)
     assert ind.shape == (len(source), k)
 
-    assert_array_equal(np_dist, dist.cpu().numpy())
+    assert_allclose(np_dist, dist.cpu().numpy())
     assert_array_equal(np_ind, ind.cpu().numpy())


### PR DESCRIPTION
Since Faiss has [torch support](https://github.com/facebookresearch/faiss/blob/main/faiss/gpu/test/torch_test_contrib_gpu.py) with tensors that are on the GPU, it is desirable to avoid moving these to and from the GPU.
This PR adds the ability to have an entire pipeline for hubness reduced nearest neighbor search on the GPU.
For some hubness reduced methods it is not feasible to do this (probably only MP-empiric).

TODO:

- [ ] Adapt TypeHints
- [ ] Try DisSimLocal adaptation